### PR TITLE
Add CIS RHEL8 manual checks and remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # Infra_Compliance
-Ansible_Automation_Infra_Compliance_Check
+
+Example Ansible playbooks that check and remediate a few RHEL 8 CIS controls.  The compliance check playbook records the status of each control and writes a simple HTML report using a Jinja2 template.
+
+## Files
+
+- `playbooks/rhel8_cis_check.yml` – runs several CIS checks and saves `/tmp/cis_report.html` on the target host.
+- `playbooks/rhel8_cis_remediate.yml` – applies the fixes for those controls using Ansible tasks.
+- `inventory.ini` – simple inventory pointing to localhost for testing.
+- `templates/report.html.j2` – Jinja2 template used by the check playbook to generate the report.
+
+## Usage
+
+Run the compliance scan:
+
+```bash
+ansible-playbook -i inventory.ini playbooks/rhel8_cis_check.yml
+```
+
+After execution, open `/tmp/cis_report.html` on the target host to view the results.
+
+Run the remediation playbook with:
+
+```bash
+ansible-playbook -i inventory.ini playbooks/rhel8_cis_remediate.yml
+```
+
+This applies the fixes defined in the playbook.

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,0 +1,2 @@
+[target]
+localhost ansible_connection=local

--- a/playbooks/rhel8_cis_check.yml
+++ b/playbooks/rhel8_cis_check.yml
@@ -1,0 +1,54 @@
+- name: RHEL8 CIS compliance check
+  hosts: all
+  become: yes
+  tasks:
+    - name: Initialize result list
+      set_fact:
+        cis_results: []
+
+    - name: Check chrony package installed
+      shell: rpm -q chrony
+      register: chrony_check
+      changed_when: false
+      ignore_errors: yes
+
+    - name: Record chrony result
+      set_fact:
+        cis_results: "{{ cis_results + [{'id': '2.2.1', 'description': 'chrony package installed', 'status': 'PASS' if chrony_check.rc == 0 else 'FAIL'}] }}"
+
+    - name: Check firewalld enabled
+      command: systemctl is-enabled firewalld
+      register: firewalld_check
+      changed_when: false
+      ignore_errors: yes
+
+    - name: Record firewalld result
+      set_fact:
+        cis_results: "{{ cis_results + [{'id': '3.5.1', 'description': 'firewalld service enabled', 'status': 'PASS' if firewalld_check.rc == 0 and 'enabled' in firewalld_check.stdout else 'FAIL'}] }}"
+
+    - name: Check PASS_MAX_DAYS set to 90
+      shell: grep -E '^PASS_MAX_DAYS\s+90' /etc/login.defs
+      register: passmax_check
+      changed_when: false
+      ignore_errors: yes
+
+    - name: Record PASS_MAX_DAYS result
+      set_fact:
+        cis_results: "{{ cis_results + [{'id': '5.4.1.1', 'description': 'PASS_MAX_DAYS is 90', 'status': 'PASS' if passmax_check.rc == 0 else 'FAIL'}] }}"
+
+    - name: Check PermitRootLogin disabled
+      shell: grep -E '^PermitRootLogin\s+no' /etc/ssh/sshd_config
+      register: rootlogin_check
+      changed_when: false
+      ignore_errors: yes
+
+    - name: Record PermitRootLogin result
+      set_fact:
+        cis_results: "{{ cis_results + [{'id': '5.2.8', 'description': 'PermitRootLogin disabled', 'status': 'PASS' if rootlogin_check.rc == 0 else 'FAIL'}] }}"
+
+    - name: Generate HTML report
+      template:
+        src: ../templates/report.html.j2
+        dest: /tmp/cis_report.html
+      vars:
+        cis_results: "{{ cis_results }}"

--- a/playbooks/rhel8_cis_remediate.yml
+++ b/playbooks/rhel8_cis_remediate.yml
@@ -1,0 +1,32 @@
+- name: RHEL8 CIS remediation
+  hosts: all
+  become: yes
+  handlers:
+    - name: restart sshd
+      service:
+        name: sshd
+        state: restarted
+  tasks:
+    - name: Ensure chrony is installed
+      package:
+        name: chrony
+        state: present
+
+    - name: Enable and start firewalld
+      service:
+        name: firewalld
+        enabled: yes
+        state: started
+
+    - name: Set PASS_MAX_DAYS to 90
+      lineinfile:
+        path: /etc/login.defs
+        regexp: '^PASS_MAX_DAYS'
+        line: 'PASS_MAX_DAYS 90'
+
+    - name: Disable root SSH login
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^PermitRootLogin'
+        line: 'PermitRootLogin no'
+      notify: restart sshd

--- a/templates/report.html.j2
+++ b/templates/report.html.j2
@@ -1,0 +1,22 @@
+<html>
+<head>
+    <title>CIS Compliance Report</title>
+</head>
+<body>
+    <h1>RHEL 8 CIS Compliance Report</h1>
+    <table border="1">
+        <tr>
+            <th>ID</th>
+            <th>Description</th>
+            <th>Status</th>
+        </tr>
+        {% for item in cis_results %}
+        <tr>
+            <td>{{ item.id }}</td>
+            <td>{{ item.description }}</td>
+            <td>{{ item.status }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement simple CIS checks without using OpenSCAP
- add remediation tasks instead of oscap --remediate
- generate a HTML compliance report using a Jinja2 template
- document new approach in README

## Testing
- `ansible-playbook --syntax-check playbooks/rhel8_cis_check.yml` *(fails: command not found)*
- `ansible-playbook --syntax-check playbooks/rhel8_cis_remediate.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525637ae148326ae7883c6009883c0